### PR TITLE
Correctly match GitHub usernames

### DIFF
--- a/levels/open_source/objectives/09_make_pr/validator.js
+++ b/levels/open_source/objectives/09_make_pr/validator.js
@@ -23,7 +23,7 @@ module.exports = async helper => {
 
     const prOwner = parsedResponseBody.user.login;
 
-    if (prOwner !== TQ_GITHUB_USERNAME) {
+    if (prOwner.toLowerCase() !== TQ_GITHUB_USERNAME.toLowerCase()) {
       helper.fail(
         `We found the Pull Request #${prNumber} on the Open Pixel Art remote repository, but it doesn't belong to your GitHub user "${TQ_GITHUB_USERNAME}"!`
       );


### PR DESCRIPTION
Usernames can be stored on GitHub with uppercase characters, but are ultimately case insensitive (https://github.com/PHILNASH === https://github.com/philnash). 

This change suggests downcasing GitHub usernames when comparing the username entered in TQ to the username returned from the GitHub API.