### PR TITLE
Fixed Bug With Executing Git From Path With Spaces

### DIFF
--- a/scripts/objectiveValidation.js
+++ b/scripts/objectiveValidation.js
@@ -14,8 +14,8 @@ async function execGitWithArgs(helper, argString, execOptions = {}) {
   // Git path had spaces. During that time, we recommended player's add quotes to their environment
   // variable to circumvent the issue. Since we're doing that ourselves now, we want to be sure player's aren't
   if (
-    (TQ_GIT_EXE.startsWith('"') && TQ_GIT_EXE.endsWith('"')) ||
-    (TQ_GIT_EXE.startsWith("'") && TQ_GIT_EXE.endsWith("'"))
+    TQ_GIT_EXE.startsWith('"') || TQ_GIT_EXE.endsWith('"') ||
+    TQ_GIT_EXE.startsWith("'") || TQ_GIT_EXE.endsWith("'")
   ) {
     throw new Error(
       "TwilioQuest no longer requires you to surround your git executable path with quotation marks if it contains spaces. Go into Settings -> Variables and remove any quotes around the TQ_GIT_EXE variable!"

--- a/scripts/objectiveValidation.js
+++ b/scripts/objectiveValidation.js
@@ -10,6 +10,18 @@ async function execGitWithArgs(helper, argString, execOptions = {}) {
     );
   }
 
+  // There was a bug introduced in the TQ 3.10.0 release that resulted in "exec" calls failing if the user's
+  // Git path had spaces. During that time, we recommended player's add quotes to their environment
+  // variable to circumvent the issue. Since we're doing that ourselves now, we want to be sure player's aren't
+  if (
+    (TQ_GIT_EXE.startsWith('"') && TQ_GIT_EXE.endsWith('"')) ||
+    (TQ_GIT_EXE.startsWith("'") && TQ_GIT_EXE.endsWith("'"))
+  ) {
+    throw new Error(
+      "TwilioQuest no longer requires you to surround your git executable path with quotation marks if it contains spaces. Go into Settings -> Variables and remove any quotes around the TQ_GIT_EXE variable!"
+    );
+  }
+
   return exec(`"${TQ_GIT_EXE}" ${argString}`, execOptions);
 }
 

--- a/scripts/objectiveValidation.js
+++ b/scripts/objectiveValidation.js
@@ -10,7 +10,7 @@ async function execGitWithArgs(helper, argString, execOptions = {}) {
     );
   }
 
-  return exec(`${TQ_GIT_EXE} ${argString}`, execOptions);
+  return exec(`"${TQ_GIT_EXE}" ${argString}`, execOptions);
 }
 
 module.exports = {


### PR DESCRIPTION
-Added quotes around the path that the "exec" function uses when searching for the Git executable

For issue #33 